### PR TITLE
ci(build): remove optional chunkah rechunking to prevent builder disk exhaustion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,12 +85,12 @@ jobs:
       # If you are feeling adventurous, use the new distro agnostic rechunker
       # https://github.com/coreos/chunkah
       # You can delete the Rechunk with rpm-ostree portion then if you use this
-      - name: Rechunk with Chunkah
-        id: rechunk
-        run: |
-          sudo -E $(command -v just) rechunk \
-            ${IMAGE_NAME} \
-            ${DEFAULT_TAG}
+      # - name: Rechunk with Chunkah
+      #   id: rechunk
+      #   run: |
+      #     sudo -E $(command -v just) rechunk \
+      #       ${IMAGE_NAME} \
+      #       ${DEFAULT_TAG}
 
       - name: Generate Build Tags
         id: gen-build-tags


### PR DESCRIPTION
Bazzite is already rechunked upstream by the Universal Blue builders. Running `chunkah` on personal customization builds is redundant and causes severe storage amplification (3x-4x the original image size), which regularly exhausts the 72GB disk of standard GHA runner VMs and fails the pipeline.

This PR comments out the optional `Rechunk with Chunkah` step. Tested and verified on GHA.